### PR TITLE
ci: disable CodeQL and harden integration smoke

### DIFF
--- a/.github/workflows/_reusable-integration-smoke.yml
+++ b/.github/workflows/_reusable-integration-smoke.yml
@@ -60,9 +60,30 @@ jobs:
 
       - name: Wait and call health endpoint
         run: |
-          echo "Waiting 20 seconds for Spring Boot to start..."
-          sleep 20
-          curl -f http://localhost:8080/actuator/health
+          set -euo pipefail
+          echo "Waiting up to 120s for backend health..."
+          for i in $(seq 1 24); do
+            if curl -fsS http://localhost:8080/actuator/health > /dev/null; then
+              echo "Backend is healthy."
+              exit 0
+            fi
+            echo "Not ready yet (${i}/24). Sleeping 5s..."
+            sleep 5
+          done
+          echo "Backend did not become healthy in time."
+          exit 1
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          echo "==== docker ps ===="
+          docker ps -a || true
+          echo ""
+          echo "==== postgres logs ===="
+          docker logs postgres --tail 200 || true
+          echo ""
+          echo "==== backend logs ===="
+          docker logs backend-integration --tail 400 || true
 
       - name: End integration smoke group
         if: always()

--- a/.github/workflows/ci-feature.yml
+++ b/.github/workflows/ci-feature.yml
@@ -71,15 +71,6 @@ jobs:
     if: needs.changes.outputs.devops == 'true'
     uses: ./.github/workflows/_reusable-lint-devops.yml
 
-  codeql-java:
-    needs: changes
-    if: needs.changes.outputs.backend == 'true'
-    permissions:
-      contents: read
-      actions: read
-      security-events: write
-    uses: ./.github/workflows/_reusable-codeql-java.yml
-
   gitleaks:
     name: GitLeaks Scan
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,22 +68,12 @@ jobs:
     if: needs.changes.outputs.devops == 'true'
     uses: ./.github/workflows/_reusable-lint-devops.yml
 
-  codeql-java:
-    needs: changes
-    if: needs.changes.outputs.backend == 'true'
-    permissions:
-      contents: read
-      actions: read
-      security-events: write
-    uses: ./.github/workflows/_reusable-codeql-java.yml
-
   build-images:
     name: Build backend image
     needs:
       - lint-test-backend
       - lint-data-engineering
       - lint-devops
-      - codeql-java
     uses: ./.github/workflows/_reusable-build-backend-image.yml
     with:
       image-name: servicehub-backend


### PR DESCRIPTION


## What does this PR do?
- Improves CI integration smoke testing by waiting up to ~120s for the backend to become healthy and, on failure, printing actionable container diagnostics (`docker ps` + logs for `postgres` and `backend-integration`).
- Disables CodeQL across all branches for now to avoid pipeline failures/noise while code scanning is not enabled.

## Related Issue / Task
N/A

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] 🔧 DevOps / Infrastructure change
- [ ] ♻️ Refactoring (no functional changes)

## How Has This Been Tested?
- [ ] Unit tests pass (`mvn test`)
- [x] Manual testing (describe what you tested)
- [ ] Docker build works (`docker-compose up --build`)

Manual testing:
- Ran GitHub Actions CI for this branch and confirmed the integration smoke step now retries health checks and emits container logs when health does not come up in time.

## Checklist
- [x] My code follows the project code style
- [x] I have added/updated comments explaining non-obvious logic
- [ ] I have added tests that prove my fix/feature works
- [x] All existing tests pass locally
- [ ] I have updated documentation if needed
- [x] My branch is up to date with `develop`

## Screenshots (if applicable)
N/A